### PR TITLE
Fix gif.gf link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Our simple and quick first stab at connecting the dots between text sentiment-analysis APIs and the GIFGIF API.
 
-[See a running demo here](http://gif.gf/labs/text)
+[See a running demo here](http://www.gif.gf/labs/text)
 
 
 


### PR DESCRIPTION
Sorry, the requested URL 'http://gif.gf/labs/text' caused an error:
Not found: '/labs/text'
